### PR TITLE
Using variables in outputFile-name

### DIFF
--- a/lib/gruntifier.js
+++ b/lib/gruntifier.js
@@ -413,6 +413,7 @@ var Gruntifier = function (grunt, done, bust) {
 			// We have the data, time to build
 			var build = Modulizr.ize(data, this.getRequests(tests)),
 				downloadErrors = this.downloadErrors,
+				filename = grunt.template.process(config.outputFile),
 				errorText, i, j;
 
 			if (config.uglify) {
@@ -427,11 +428,11 @@ var Gruntifier = function (grunt, done, bust) {
 			build = this.addPrefix(build, tests, customTests);
 
 			// Write!
-			grunt.file.write(config.outputFile, build);
+			grunt.file.write(filename, build);
 
 			// All set.
 			grunt.log.writeln();
-			grunt.log.ok("Wrote file to " + config.outputFile);
+			grunt.log.ok("Wrote file to " + filename);
 
 			if (downloadErrors.length) {
 				errorText = ["The following tests were not found"];


### PR DESCRIPTION
Filenames that use variables like `<%= pkg.version %>` or something
similar are now getting replaced with the corresponding variables.
#### Example:

```
modernizr: {
    …
    outputFile: "dist/js/modernizr-for-version-<%= pkg.version %>.min.js
    …
}
```

The output file is now stored in `dist/js/modernizr-for-version-2.0.0.min.js` if the current version of a project in the package.json-file is set to 2.0.0.

This PR is missing the replacement of variables in `modernizr.devFile`.
