### PR TITLE
Make grunt-modernizr compatible to Grunt 0.4

### DIFF
--- a/lib/gruntifier.js
+++ b/lib/gruntifier.js
@@ -166,7 +166,7 @@ var Gruntifier = function (grunt, done, bust) {
 
 			grunt.log.subhead("Looking for Modernizr references");
 
-			files = grunt.file.expandFiles(config.files);
+			files = grunt.file.expand({filter: 'isFile'}, config.files);
 			exclude = _defaults.excludeFiles.concat(config.excludeFiles);
 
 			// Exclude developer build
@@ -377,7 +377,7 @@ var Gruntifier = function (grunt, done, bust) {
 				}
 
 				promise.when(this.xhr(communityRequests)).then(function (community) {
-					customTests = grunt.file.expandFiles(config.customTests);
+					customTests = grunt.file.expand({filter: 'isFile'}, config.customTests);
 
 					if (customTests.length) {
 						grunt.log.subhead("Adding custom tests");


### PR DESCRIPTION
In v0.4 `grunt.file.expandFiles()` is replaced with `grunt.file.expand({filter: 'isFile'}, …)`

See https://github.com/gruntjs/grunt/wiki/Upgrading-from-0.3-to-0.4 and https://github.com/gruntjs/grunt/wiki/grunt.file
