### PR TITLE
Add ^ in modulizr regex to filter test names

### DIFF
--- a/lib/modulizr.js
+++ b/lib/modulizr.js
@@ -209,7 +209,7 @@
       source = this._removeComments(source);
 
       // Mark the tests
-      js_notests = source.replace(/tests\['(.*)'\]/g, function($0, $1) {
+      js_notests = source.replace(/^tests\['(.*)'\]/g, function($0, $1) {
         testStack[testStack.length] = {"code":$0, "name": $1};
         return 'TEST__'+$1+'__';
       });


### PR DESCRIPTION
It is necessary to check if the keyword `tests` starts in a separate line in
order to achive the correct mapping of test names and code.

This commit closes #34.
