### PR TITLE
Fix false positives

### DIFF
--- a/lib/gruntifier.js
+++ b/lib/gruntifier.js
@@ -120,7 +120,7 @@ var Gruntifier = function (grunt, done, bust) {
 			}
 
 			prefix = config.extensibility.prefixed;
-			regExp = new RegExp("(?:\\.|\\[(?:\"|'))(?:(?:no|" + prefix + ")-)?(" + _class + ")(?:(?:\"|')\\])?", "gm");
+			regExp = new RegExp("(?:\\.|\\[(?:\"|'))(?:(?:no|" + prefix + ")-)?(" + _class + ")(?:[^-_a-zA-Z]|\\n)", "gm");
 			match = (regExp).exec(data);
 
 			while (match) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -30,7 +30,6 @@ describe("grunt-modernizr", function () {
 		.expect(">> testallprops")
 		.expect(">> prefixed")
 		.expect(">> mq")
-		.expect(">> smil")
 		.expect(">> testbundle")
 		.expect(">> canvas")
 		.expect(">> webgl")


### PR DESCRIPTION
I have `.notification-bar` class in my project which case inclusion of `notification` because of too loose RegExp.

I also removed `smil` from tests because it was caught from `['smile'` in `modulizr.js`.
