### PR TITLE
Update UglifyJS from 1.x to 2.x

### DIFF
--- a/lib/gruntifier.js
+++ b/lib/gruntifier.js
@@ -284,7 +284,7 @@ var Gruntifier = function (grunt, target, done, bust) {
 					url: url.format({
 						protocol : com.protocol,
 						host : com.host,
-						pathname : (com.pathname || "") + pathname,
+						pathname : (com.pathname || "") + pathname
 					}),
 					proxy: process.env.HTTP_PROXY
 				}, _handleResponse.bind(this));
@@ -419,16 +419,14 @@ var Gruntifier = function (grunt, target, done, bust) {
 		},
 
 		addPrefix : function (build, tests, customTests) {
-			build = ";" + build + ";";
-
-			var prefix = "\/* Modernizr (Custom Build) | MIT & BSD" +
+			var prefix = "\/*! Modernizr (Custom Build) | MIT & BSD" +
 			"\n * Build: http://modernizr.com/download/#-" + tests.join("-") +
 			(customTests.length ? "\n * Custom Tests: " + customTests.map(function (test) {
 				return path.basename(test);
 			}).join(", ") : "") +
 			"\n */\n";
 
-			return prefix + build;
+			return prefix + ";" + build;
 		},
 
 		finalize : function (data, tests, customTests) {
@@ -444,7 +442,12 @@ var Gruntifier = function (grunt, target, done, bust) {
 					grunt.log.ok("Uglifying");
 				}
 
-				build = uglify(build, ["--extra", "--unsafe"]);
+				build = uglify.minify(build, {
+					fromString: true,
+					compress: {
+						unsafe: true
+					}
+				}).code;
 			} else if (!_quiet) {
 				grunt.log.ok("Skipping uglify");
 			}

--- a/package.json
+++ b/package.json
@@ -29,17 +29,17 @@
     "node": "*"
   },
   "dependencies": {
-    "uglify-js": "1.3.3",
-    "promised-io": "0.3.x",
-    "colors": "0.6.x",
+    "uglify-js": "~2.4.6",
+    "promised-io": "~0.3.4",
+    "colors": "~0.6.2",
     "request": "~2.27.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.7.0",
-    "grunt-contrib-nodeunit": "0.1.2",
-    "grunt-contrib-watch": "~0.3.1",
-    "mocha": ">=1.6.0",
+    "grunt": "~0.4.2",
+    "grunt-contrib-jshint": "~0.7.2",
+    "grunt-contrib-nodeunit": "~0.2.2",
+    "grunt-contrib-watch": "~0.5.3",
+    "mocha": ">=1.14.0",
     "nexpect": ">=0.2.4"
   },
   "scripts": {


### PR DESCRIPTION
UglifyJS v2 can save more file size as compared with v1.
(cf. http://lisperator.net/blog/should-you-switch-to-uglifyjs2/)

The build result of `build/modernizr-custom.js` (without any options) is here:

| UglifyJS's version | File size (byte) |
| --- | :-- |
| v1.3.3 | 15,920 |
| v2.4.6 | 15,807 |

So I updated `package.json` and `lib/gruntifier.js` to use UglifyJS2.
