### PR TITLE
License should be preserved

### DIFF
--- a/lib/gruntifier.js
+++ b/lib/gruntifier.js
@@ -470,7 +470,7 @@ var Gruntifier = function (grunt, target, done, bust) {
 		addLicencePrefix : function (build, tests, customTests) {
 			build = ";" + build + ";";
 
-			var prefix = "\/* Modernizr (Custom Build) | MIT & BSD" +
+			var prefix = "\/*! Modernizr (Custom Build) | MIT & BSD" +
 			"\n * Build: http://modernizr.com/download/#-" + tests.join("-") +
 			(customTests.length ? "\n * Custom Tests: " + customTests.map(function (test) {
 				return path.basename(test);


### PR DESCRIPTION
License should be preserved, if you don't use the built-in uglify task.
