### PR TITLE
Make matchCommunityTests work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-modernizr",
   "description": "Build out a lean, mean Modernizr machine.",
-  "version": "0.5.3",
+  "version": "0.5.2",
   "homepage": "https://github.com/doctyper/grunt-modernizr",
   "author": {
     "name": "Richard Herrera",


### PR DESCRIPTION
The `matchCommunityTests` option to ignore community tests was being ORed so it didn't matter what it was set to.

`getCommunityRequests` fixed issues #85 #86 but I also added it to `mapClass` as it seemed to make sense but someone with more knowledge of the src might want to check that one.
