### PR TITLE
Fix issue with documentation on cache busting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ grunt.loadNpmTasks("grunt-modernizr");
 
 ### Command Line
 
-Run the task with `grunt modernizr`.
+Run the task with `grunt modernizr:dist`.
 
 #### Cache Busting
 
-Bust the cache of locally downloaded files by running `grunt modernizr:bust`
+Bust the cache of locally downloaded files by running `grunt modernizr:dist:bust`
 
 ### Config Options
 


### PR DESCRIPTION
Command "grunt modernizr:bust" doesn't work with registerMultiTask because it expects "bust" to be a valid target. In order to pass an argument to the MultiTask function you must use the format "grunt task:target:arg1".
