### PR TITLE
fix(communityTests): find the correct module by test name

### DIFF
--- a/lib/gruntifier.js
+++ b/lib/gruntifier.js
@@ -26,6 +26,25 @@ var Gruntifier = function (grunt, target, done, bust) {
 	var Mappr = require("./customappr"),
 		_classes = Mappr._classes;
 
+
+	var getModuleByTest = function (test) {
+		for (var key in _classes) {
+			if (_classes.hasOwnProperty(key)) {
+				// value is an array
+				if (Object.prototype.toString.call(_classes[key]) === '[object Array]') {
+					if (_classes[key].indexOf(test) !== -1) {
+						return key;
+					}
+				}
+
+				// value is not an array
+				else if (_classes[key] === test) {
+					return key;
+				}
+			}
+		}
+	};
+
 	var _Gruntifier = function () {
 		this.stringMatches = {};
 		this.downloadErrors = [];
@@ -233,7 +252,13 @@ var Gruntifier = function (grunt, target, done, bust) {
 			}
 
 			for (key in this.stringMatches) {
-				tests.push(key);
+				var mappedTest = getModuleByTest(key)
+				if(mappedTest===undefined){
+					tests.push(key);
+				}
+				else{
+					tests.push(mappedTest);
+				}
 			}
 
 			return this.filterTests(tests);


### PR DESCRIPTION
Fix a bug for community tests where the test and module name are not the same. Eg: test is `csspositionsticky` but the module is `css-positionsticky` so it cannot find the correct test file.

It is not a good idea to add tests for community tests as it takes a long time to download all the files (this might be the cause of the bug) unless refactoring the tests. I can do it if it's needed :)
