### PR TITLE
V2 fallback

### DIFF
--- a/lib/gruntifier.js
+++ b/lib/gruntifier.js
@@ -433,11 +433,11 @@ var Gruntifier = function (grunt, target, done, bust) {
 			}
 
 			promise.all(
-				this.xhr(_private.url.domain, _private.paths.modernizr),
+				this.xhr(_private.url.raw, _private.paths.modernizr),
 
 				// Check for special case flags, load conditionally
-				(config.extra.printshiv) ? this.xhr(_private.url.domain, _private.paths.printshiv) : null,
-				(config.extra.load) ? this.xhr(_private.url.domain, _private.paths.load) : null
+				(config.extra.printshiv) ? this.xhr(_private.url.raw, _private.paths.printshiv) : null,
+				(config.extra.load) ? this.xhr(_private.url.raw, _private.paths.load) : null
 			).then(function (data) {
 				main = data.join("");
 

--- a/lib/helpers/private.js
+++ b/lib/helpers/private.js
@@ -71,9 +71,9 @@
 		],
 
 		"paths" : {
-			"modernizr" : "downloads/modernizr-latest.js",
-			"printshiv" : "i/js/html5shiv-printshiv-3.6.js",
-			"load" : "i/js/modernizr.load.1.5.4.js",
+			"modernizr" : "Modernizr/modernizr.com/v3/downloads/modernizr-latest.js",
+			"printshiv" : "Modernizr/modernizr.com/v3/i/js/html5shiv-printshiv-3.6.1.js",
+			"load" : "Modernizr/modernizr.com/v3/i/js/modernizr.load.1.5.4.js",
 			"community" : "Modernizr/Modernizr/87c723720a48254ae37ffd56829e32a96f5c5496/feature-detects/%s.js"
 		}
 	};

--- a/lib/helpers/private.js
+++ b/lib/helpers/private.js
@@ -71,9 +71,9 @@
 		],
 
 		"paths" : {
-			"modernizr" : "Modernizr/modernizr.com/v3/downloads/modernizr-latest.js",
-			"printshiv" : "Modernizr/modernizr.com/v3/i/js/html5shiv-printshiv-3.6.1.js",
-			"load" : "Modernizr/modernizr.com/v3/i/js/modernizr.load.1.5.4.js",
+			"modernizr" : "Modernizr/modernizr.com/gh-pages/downloads/modernizr-latest.js",
+			"printshiv" : "Modernizr/modernizr.com/gh-pages/i/js/html5shiv-printshiv-3.7.1.js",
+			"load" : "Modernizr/modernizr.com/gh-pages/i/js/modernizr.load.1.5.4.js",
 			"community" : "Modernizr/Modernizr/87c723720a48254ae37ffd56829e32a96f5c5496/feature-detects/%s.js"
 		}
 	};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-modernizr",
   "description": "Build out a lean, mean Modernizr machine.",
-  "version": "0.6.0",
+  "version": "0.6.1-pre",
   "homepage": "https://github.com/doctyper/grunt-modernizr",
   "author": {
     "name": "Richard Herrera",


### PR DESCRIPTION
Building on https://github.com/GrimaceOfDespair/grunt-modernizr/commit/9846457ce8578dede5873fd4cb64e21cf0af9590, use the Github locations for the necessary files instead of the website locations now respond with 404 errors.