### PR TITLE
Cross platform support for post install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "test": "grunt clean; node test/runner.js",
-    "postinstall": "if [[ -d node_modules/modernizr ]]; then ( cd node_modules/modernizr; npm install --production; cd -; ); fi"
+    "postinstall": "node postinstall.js"
   },
   "keywords": [
     "gruntplugin",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,23 @@
+// Node Script to perform the original bash command:
+//
+//     if [[ -d node_modules/modernizr ]]; then ( cd node_modules/modernizr; npm install --production; cd -; ); fi
+
+var fs = require('fs');
+var exec = require('child_process').exec;
+
+var on_module_stat = function (error, stat) {
+    if (error === null) {
+        exec('cd node_modules/modernizr && npm install --production', on_install);
+    }
+};
+
+var on_install = function (error, stdout, stderr) {
+    if (error !== null) {
+        console.log('Error executing grunt-modernizr postinstall' + error);
+        console.log(stderr);
+    }
+
+    console.log('grunt-modernizr postinstall sucess');
+};
+
+fs.stat('node_modules/modernizr', on_module_stat);


### PR DESCRIPTION
This should be a fix for [Unable to install grunt-modernizr 1.0.0 on Windows #125](https://github.com/Modernizr/grunt-modernizr/issues/125). I've changed the bash script to a node script to allow support on non bash environments.