### PR TITLE
replaced 'outputFile' with 'dest' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ modernizr: {
     "parseFiles": true,
     "customTests": [],
     "devFile": "/PATH/TO/modernizr-dev.js",
-    "outputFile": "/PATH/TO/modernizr-output.js",
+    "dest": "/PATH/TO/modernizr-output.js",
     "tests": [
       // Tests
     ],

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Add a `modernizr` config object to your Gruntfile.js file. The task supports mul
 ```javascript
 modernizr: {
   dist: {
-    "dest" : "build/modernizr-custom.js",
     "parseFiles": true,
     "customTests": [],
     "devFile": "/PATH/TO/modernizr-dev.js",


### PR DESCRIPTION
The output file option name has changed since 0.x. Changed readme example to match.