### PR TITLE
Fix link to Modernizr in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![NPM](https://nodei.co/npm/grunt-modernizr.png?compact=true)](https://nodei.co/npm/grunt-modernizr/)
 
-A [Grunt](http://gruntjs.com/) wrapper for [Modernizr](https://github.com/doctyper/customizr).
+A [Grunt](http://gruntjs.com/) wrapper for [Modernizr](https://github.com/Modernizr/Modernizr).
 
 ## Usage
 Install this grunt plugin next to your project's [Gruntfile.js][getting_started]:


### PR DESCRIPTION
Why:

* Where it says `Modernizr` the text is in fact linking to `customizr`.

This change addresses the need by:

* Fixing the link to point to Modernizr/Modernizr.