### PR TITLE
Respect --no-color flag

### DIFF
--- a/tasks/modernizr.js
+++ b/tasks/modernizr.js
@@ -27,6 +27,11 @@ module.exports = function (grunt) {
 		var customizr = require("customizr");
 		var _merge = require("lodash.merge");
 		var settings = _merge(this.options(), this.data);
+		
+		var noColors = grunt.option('no-color') === true;
+		if (noColors) {
+			settings.noColors = true;
+		}
 
 		// Go!
 		return customizr(settings, done);


### PR DESCRIPTION
Since `customizr` didn't have access to Grunt params, we will pass `--no-color` flag directly.

Fix #149 