### PR TITLE
specify a hash; save upstream builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": "*"
   },
   "dependencies": {
-    "customizr": "https://github.com/Modernizr/customizr/tarball/develop",
+    "customizr": "https://github.com/Modernizr/customizr/tarball/develop#e5890ed4b4fedb69da50ffbae39577788970d8ee",
     "lodash.merge": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
yarn resolves branches to a hash but downloads the latest commit from that branch when running a fresh install. When a branched dep is updated, installs will fail because yarn isn't getting the hash it expects.

```
#!/bin/bash -eo pipefail
if [ ! -d ./node_modules ]; then
  yarn --pure-lockfile
fi
yarn install v1.6.0
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
error https://github.com/Modernizr/customizr/tarball/develop: Fetch succeeded for undefined. However, extracting "https://github.com/Modernizr/customizr/tarball/develop" resulted in hash "bf72bdbc0e693e253cfc2b80180eb7b984753111", which did not match the requested hash "a15f0296a0a2488177085aec4ff42c7aaf5510ef".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Exited with code 1
```