### PR TITLE
Use NPM packages for customizr and modernizr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
   - npm cache clean -g
 language: node_js
 node_js:
-  - "0.10"
+  - "lts/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 before_install:
   # Node
   - npm install grunt-cli -g
-  - npm cache verify -g
+  - npm cache verify
 language: node_js
 node_js:
   - "lts/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 before_install:
   # Node
   - npm install grunt-cli -g
-  - npm cache clean -g
+  - npm cache verify -g
 language: node_js
 node_js:
   - "lts/*"

--- a/package.json
+++ b/package.json
@@ -25,18 +25,19 @@
     "node": "*"
   },
   "dependencies": {
-    "customizr": "https://github.com/Modernizr/customizr/tarball/develop",
+    "customizr": "^1.1.0",
     "lodash.merge": "^4.0.1"
   },
   "devDependencies": {
     "assert": "~1.1.0",
-    "grunt": "~0.4.2",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.0",
     "grunt-contrib-nodeunit": "0.4.1",
     "grunt-contrib-watch": "~0.3.1",
     "mocha": "~1.17.0",
-    "modernizr": "https://github.com/Modernizr/Modernizr/tarball/master",
+    "modernizr": "^3.6.0",
     "nexpect": "~0.3.0"
   },
   "scripts": {


### PR DESCRIPTION
Instead of pointing to github URLs that will download the current source for the customizr (dev branch) and modernizr (master branch) the published NPM packages for this should be used.

When using yarn as package manager, the package manager will save the hash of the downloaded external source so every time they are changed the installation will be broken. This is discussed in https://github.com/Modernizr/grunt-modernizr/issues/146.

Not sure what the postinstall.js script is doing but tested to remove it and for me the grunt-modernizr is working without running that script.