### PR TITLE
Updated dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
   - npm cache clean -g
 language: node_js
 node_js:
-  - "0.10"
+  - "6"

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     "lodash.merge": "^4.0.1"
   },
   "devDependencies": {
-    "assert": "~1.1.0",
-    "grunt": "~0.4.2",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-jshint": "~0.7.0",
-    "grunt-contrib-nodeunit": "0.4.1",
-    "grunt-contrib-watch": "~0.3.1",
-    "mocha": "~1.17.0",
+    "assert": "~1.4.1",
+    "grunt": "~1.0.3",
+    "grunt-contrib-clean": "~2.0.0",
+    "grunt-contrib-jshint": "~2.0.0",
+    "grunt-contrib-nodeunit": "2.0.0",
+    "grunt-contrib-watch": "~1.1.0",
+    "mocha": "~5.2.0",
     "modernizr": "https://github.com/Modernizr/Modernizr/tarball/master",
-    "nexpect": "~0.3.0"
+    "nexpect": "~0.5.0"
   },
   "scripts": {
     "test": "grunt clean; node test/runner.js",


### PR DESCRIPTION
I've noticed a lot of warnings when running yarn install in this project. 

```bash
warning grunt > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning grunt > glob > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning grunt > glob > graceful-fs@1.2.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
warning grunt > findup-sync > glob > minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning grunt > coffee-script@1.3.3: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
warning grunt-contrib-jshint > jshint > minimatch@0.4.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning grunt-contrib-nodeunit > nodeunit > tap > coveralls > request > hawk > hoek@2.16.3: The major version is no longer supported. Please update to 4.x or newer
warning grunt-contrib-nodeunit > nodeunit > tap > coveralls > request > hawk > boom > hoek@2.16.3: The major version is no longer supported. Please update to 4.x or newer
warning grunt-contrib-nodeunit > nodeunit > tap > coveralls > request > hawk > sntp > hoek@2.16.3: The major version is no longer supported. Please update to 4.x or newer
warning grunt-contrib-watch > gaze > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning grunt-contrib-watch > gaze > fileset > minimatch@0.4.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning mocha > glob > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
warning mocha > glob > graceful-fs@2.0.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
warning mocha > jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
```

```bash
26 vulnerabilities found - Packages audited: 1681
Severity: 8 Low | 9 Moderate | 9 High
```
So I've updated all the dev dependencies. After Updating the dependencies tests run fine and no warnings are shown opon installation. 
```bash
1 vulnerabilities found - Packages audited: 129
Severity: 1 Low

```